### PR TITLE
feat: add suppressWarnings option

### DIFF
--- a/src/__test__/executeDot.test.ts
+++ b/src/__test__/executeDot.test.ts
@@ -28,6 +28,15 @@ describe('executeDot', () => {
     });
   });
 
+  test('suppress warning messages as an option', async () => {
+    await executeDot(dot, {
+      suppressWarnings: true,
+    });
+    expect(execFile).toBeCalledWith('dot', ['-q', '/path/to/mock'], {
+      encoding: 'buffer',
+    });
+  });
+
   test('format can be specified as an option', async () => {
     await executeDot(dot, {
       format: 'pdf',

--- a/src/executeDot.ts
+++ b/src/executeDot.ts
@@ -7,7 +7,7 @@ import { ExecuteOption } from './types';
  */
 export async function executeDot(
   dot: string,
-  { format, output, dotCommand: cmd = 'dot', childProcessOptions = {} }: ExecuteOption = {},
+  { format, output, suppressWarnings, dotCommand: cmd = 'dot', childProcessOptions = {} }: ExecuteOption = {},
 ): Promise<Buffer> {
   const { fd, path, cleanup } = await file();
   try {
@@ -15,6 +15,9 @@ export async function executeDot(
     await close(fd);
 
     const args: string[] = [];
+    if (suppressWarnings === true) {
+      args.push('-q');
+    }
     if (typeof format === 'string') {
       args.push(`-T${format}`);
     }

--- a/src/exportToBuffer.ts
+++ b/src/exportToBuffer.ts
@@ -1,11 +1,13 @@
 import { IRootCluster, toDot } from 'ts-graphviz';
-import { Format } from './types';
+import { ExecuteOption } from './types';
 import { executeDot } from './executeDot';
+
+type Option = Omit<ExecuteOption, 'output'>;
 
 /**
  * Returns the Graphviz output result as a buffer.
  */
-export async function exportToBuffer(dot: IRootCluster | string, options: { format?: Format } = {}): Promise<Buffer> {
+export async function exportToBuffer(dot: IRootCluster | string, options: Option = {}): Promise<Buffer> {
   const input = typeof dot === 'string' ? dot : toDot(dot);
   return await executeDot(input, options);
 }

--- a/src/exportToFile.ts
+++ b/src/exportToFile.ts
@@ -1,5 +1,5 @@
 import { IRootCluster, toDot } from 'ts-graphviz';
-import { DotOption, ExecuteDotOption } from './types';
+import { DotOption, ExecuteDotOption, OutputOption } from './types';
 import { executeDot } from './executeDot';
 
 /**
@@ -39,7 +39,7 @@ import { executeDot } from './executeDot';
  */
 export async function exportToFile(
   dot: IRootCluster | string,
-  options: Required<ExecuteDotOption> & DotOption,
+  options: Required<OutputOption> & ExecuteDotOption & DotOption,
 ): Promise<void> {
   const input = typeof dot === 'string' ? dot : toDot(dot);
   await executeDot(input, options);

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,9 +9,16 @@ export type DotOption = {
   childProcessOptions?: ChildProcessOptions;
 };
 
-export type ExecuteDotOption = {
+export type OutputOption = {
   format?: Format;
   output?: string;
+};
+
+export type ExecuteDotOption = OutputOption & {
+  /**
+   * Suppress warning messages.
+   */
+  suppressWarnings?: boolean;
 };
 
 export type ExecuteOption = ExecuteDotOption & DotOption;


### PR DESCRIPTION
When Warning is output to stderr at the time of execution, an error occurs and an error occurs.

`suppressWarnings` is set to true and executed, Warnings are suppressed and no error occurs.

```ts
await exportToFile('digraph { a -> b }', {
  output: '/path/to/output.png',
  format: 'png',
  suppressWarnings: true,
});
```
